### PR TITLE
infra: initialize project structure, base types, and config loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# Dependencies
+node_modules/
+
+# Environment secrets
+.env
+
+# WhatsApp session
+.wwebjs_auth/
+.wwebjs_cache/
+
+# Temp audio files
+tmp/
+
+# Pending approvals (transient bot state)
+pending.json
+
+# Puppeteer cache
+.local-chromium/
+
+# Logs
+logs/
+*.log
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Editor
+.vscode/
+.idea/

--- a/adapters/base.js
+++ b/adapters/base.js
@@ -1,0 +1,46 @@
+const { EventEmitter } = require('events');
+
+/**
+ * @typedef {Object} NormalizedMessage
+ * @property {'whatsapp'|'telegram'} channelId
+ * @property {string} from - Native channel ID (phone number or Telegram user ID)
+ * @property {'voice'|'text'} type
+ * @property {string|null} text - Text content (null if voice)
+ * @property {string|null} audioPath - Local path to downloaded audio file (null if text)
+ * @property {function(string): Promise<void>} reply - Send a reply to the user
+ * @property {function(string): Promise<void>} replyVoice - Alias for reply
+ */
+
+class ChannelAdapter extends EventEmitter {
+    /** @returns {Promise<void>} */
+    async connect() {
+        throw new Error('Not implemented: connect()');
+    }
+
+    /**
+     * @param {string} to
+     * @param {string} text
+     * @returns {Promise<void>}
+     */
+    async send(to, text) {
+        throw new Error('Not implemented: send()');
+    }
+
+    /**
+     * @param {*} rawMsg
+     * @returns {Promise<string>} Local path to downloaded audio file
+     */
+    async downloadAudio(rawMsg) {
+        throw new Error('Not implemented: downloadAudio()');
+    }
+
+    /**
+     * @param {*} msg
+     * @returns {boolean}
+     */
+    isAuthorized(msg) {
+        throw new Error('Not implemented: isAuthorized()');
+    }
+}
+
+module.exports = ChannelAdapter;

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -1,0 +1,22 @@
+channels:
+  whatsapp:
+    enabled: false
+    allowedNumber: ""
+    sessionPath: ".wwebjs_auth"
+  telegram:
+    enabled: false
+    allowedUserId: ""
+
+vault:
+  path: ""
+  categoriesFile: "categories.json"
+  inboxFolder: "_Inbox"
+  inboxTag: "a-classer"
+
+whisper:
+  model: "medium"
+  language: "fr"
+
+pipeline:
+  categoryApprovalTimeoutMin: 10
+  audioTmpPath: "./tmp/audio"

--- a/config/loader.js
+++ b/config/loader.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+
+const CONFIG_FILE = path.join(__dirname, '..', 'config.yaml');
+
+let _config = null;
+
+function loadConfig() {
+    if (_config) return _config;
+
+    if (!fs.existsSync(CONFIG_FILE)) {
+        throw new Error(
+            `config.yaml not found. Run "voicenote setup" first.\nExpected: ${CONFIG_FILE}`
+        );
+    }
+
+    const raw = yaml.load(fs.readFileSync(CONFIG_FILE, 'utf8'));
+    _config = {
+        channels: {
+            whatsapp: {
+                enabled: raw.channels?.whatsapp?.enabled ?? false,
+                allowedNumber: process.env.WA_ALLOWED_NUMBER || raw.channels?.whatsapp?.allowedNumber,
+                sessionPath: raw.channels?.whatsapp?.sessionPath || '.wwebjs_auth',
+            },
+            telegram: {
+                enabled: raw.channels?.telegram?.enabled ?? false,
+                allowedUserId: process.env.TG_ALLOWED_USER_ID || String(raw.channels?.telegram?.allowedUserId || ''),
+                token: process.env.TG_BOT_TOKEN,
+            },
+        },
+        vault: {
+            path: process.env.VAULT_PATH || raw.vault?.path,
+            categoriesFile: process.env.CATEGORIES_FILE || path.join(process.env.VAULT_PATH || raw.vault?.path, raw.vault?.categoriesFile || 'categories.json'),
+            inboxFolder: raw.vault?.inboxFolder || '_Inbox',
+            inboxTag: raw.vault?.inboxTag || 'a-classer',
+        },
+        whisper: {
+            model: process.env.WHISPER_MODEL || raw.whisper?.model || 'medium',
+            language: process.env.WHISPER_LANGUAGE || raw.whisper?.language || 'fr',
+        },
+        pipeline: {
+            categoryApprovalTimeoutMin: parseInt(
+                process.env.CATEGORY_APPROVAL_TIMEOUT_MIN || raw.pipeline?.categoryApprovalTimeoutMin || 10
+            ),
+            audioTmpPath: process.env.TMP_PATH || raw.pipeline?.audioTmpPath || path.join(__dirname, '..', 'tmp', 'audio'),
+            pendingFile: process.env.PENDING_FILE || path.join(__dirname, '..', 'pending.json'),
+        },
+        api: {
+            groqApiKey: process.env.GROQ_API_KEY,
+        },
+    };
+
+    validate(_config);
+    return _config;
+}
+
+function validate(config) {
+    const errors = [];
+
+    if (!config.vault.path) errors.push('VAULT_PATH is required');
+    if (!config.api.groqApiKey) errors.push('GROQ_API_KEY is required in .env');
+
+    const waEnabled = config.channels.whatsapp.enabled;
+    const tgEnabled = config.channels.telegram.enabled;
+
+    if (!waEnabled && !tgEnabled) {
+        errors.push('At least one channel (whatsapp or telegram) must be enabled in config.yaml');
+    }
+    if (waEnabled && !config.channels.whatsapp.allowedNumber) {
+        errors.push('WA_ALLOWED_NUMBER is required when WhatsApp is enabled');
+    }
+    if (tgEnabled && !config.channels.telegram.token) {
+        errors.push('TG_BOT_TOKEN is required in .env when Telegram is enabled');
+    }
+    if (tgEnabled && !config.channels.telegram.allowedUserId) {
+        errors.push('TG_ALLOWED_USER_ID is required when Telegram is enabled');
+    }
+
+    if (errors.length > 0) {
+        throw new Error(`Configuration errors:\n${errors.map(e => '  - ' + e).join('\n')}`);
+    }
+}
+
+function resetConfig() {
+    _config = null;
+}
+
+module.exports = { loadConfig, resetConfig };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "voicenote-obsidian-pipeline",
+  "version": "1.0.0",
+  "description": "Voice/text message capture from WhatsApp or Telegram → Whisper transcription → Groq AI reformulation → Obsidian vault",
+  "main": "index.js",
+  "type": "commonjs",
+  "bin": {
+    "voicenote": "./bin/cli.js"
+  },
+  "scripts": {
+    "start": "node index.js",
+    "start:wa": "node index.js --wa",
+    "start:tg": "node index.js --tg",
+    "setup": "node bin/setup.js",
+    "status": "node bin/cli.js status",
+    "logs": "node bin/cli.js logs"
+  },
+  "dependencies": {
+    "whatsapp-web.js": "^1.23.0",
+    "qrcode-terminal": "^0.12.0",
+    "puppeteer": "^21.0.0",
+    "node-telegram-bot-api": "^0.66.0",
+    "uuid": "^9.0.0",
+    "inquirer": "^9.0.0",
+    "js-yaml": "^4.1.0",
+    "chalk": "^5.3.0",
+    "commander": "^11.0.0",
+    "slugify": "^1.6.6",
+    "node-fetch": "^3.3.2"
+  },
+  "engines": {
+    "node": ">=20.0.0"
+  },
+  "license": "MIT"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+faster-whisper>=1.0.0
+requests>=2.31.0
+python-slugify>=8.0.0
+python-dotenv>=1.0.0


### PR DESCRIPTION
## Summary
- Scaffolde complet du projet (dossiers, package.json, .gitignore)
- `adapters/base.js` — classe abstraite `ChannelAdapter` + typedef `NormalizedMessage`
- `config/loader.js` — chargement config.yaml + .env avec validation des champs requis
- `requirements.txt` — dépendances Python (faster-whisper, slugify, dotenv)

## Test plan
- [ ] `node -e "require('./config/loader.js')"` ne plante pas sans config.yaml (erreur claire)
- [ ] `node -e "const A = require('./adapters/base.js'); const a = new A(); a.connect()"` → throws 'Not implemented'

Closes #1