### PR TITLE
feat: implement categories manager and Obsidian vault writer (#7)

### DIFF
--- a/pipeline/categories.js
+++ b/pipeline/categories.js
@@ -1,0 +1,61 @@
+const fs = require('fs');
+const path = require('path');
+
+function getCategoriesFile() {
+    return process.env.CATEGORIES_FILE || path.join(process.env.VAULT_PATH || '', 'categories.json');
+}
+
+function loadCategories() {
+    const file = getCategoriesFile();
+    if (!fs.existsSync(file)) return [];
+    const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    return data.categories || [];
+}
+
+function addCategory(categoryPath, description) {
+    const file = getCategoriesFile();
+    let data = { version: 0, categories: [] };
+    if (fs.existsSync(file)) {
+        data = JSON.parse(fs.readFileSync(file, 'utf8'));
+    }
+    const today = new Date().toISOString().slice(0, 10);
+    data.categories.push({
+        path: categoryPath,
+        description,
+        created_at: today,
+        created_by: 'voicenote-bot',
+        validated_by: 'user',
+    });
+    data.version = (data.version || 0) + 1;
+    fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf8');
+
+    // Créer le dossier physique dans la vault
+    const vaultPath = process.env.VAULT_PATH || '';
+    const dirPath = path.join(vaultPath, categoryPath);
+    fs.mkdirSync(dirPath, { recursive: true });
+    console.log(`[categories] Nouvelle catégorie créée : ${categoryPath}`);
+}
+
+function initCategories(vaultPath, initialCategories) {
+    // initialCategories = array of strings like "Projets/Tech"
+    const file = path.join(vaultPath, 'categories.json');
+    if (fs.existsSync(file)) return;
+
+    const today = new Date().toISOString().slice(0, 10);
+    const categories = initialCategories.map(cat => ({
+        path: cat.trim(),
+        description: '',
+        created_at: today,
+        created_by: 'init',
+    }));
+
+    const data = { version: 1, categories };
+    fs.writeFileSync(file, JSON.stringify(data, null, 2), 'utf8');
+
+    for (const cat of categories) {
+        fs.mkdirSync(path.join(vaultPath, cat.path), { recursive: true });
+    }
+    console.log(`[categories] ${categories.length} catégorie(s) initiale(s) créée(s)`);
+}
+
+module.exports = { loadCategories, addCategory, initCategories };

--- a/pipeline/processor.js
+++ b/pipeline/processor.js
@@ -1,0 +1,149 @@
+const https = require('https');
+
+const GROQ_API_URL = 'https://api.groq.com/openai/v1/chat/completions';
+const GROQ_MODEL = 'llama-3.1-70b-versatile';
+const TIMEOUT_MS = 30000;
+
+function buildSystemPrompt(categories) {
+    const catList = categories.length > 0
+        ? categories.map(c => `- ${c.path}${c.description ? ' : ' + c.description : ''}`).join('\n')
+        : '- Aucune catégorie définie — suggère une catégorie appropriée';
+
+    return `Tu es un assistant de gestion de connaissances personnelles.
+Tu reçois une transcription brute d'un message vocal ou texte en français
+(hésitations, langage oral, fautes possibles).
+
+Catégories disponibles dans la vault :
+${catList}
+
+RÈGLES DE CATÉGORISATION :
+1. Analyse le sens profond de l'idée, pas juste les mots-clés.
+2. Si une catégorie existante correspond bien → utilise-la.
+3. Si l'idée est proche d'une catégorie sans être exactement dedans
+   → rattache-la à la catégorie la plus proche ET justifie ton choix.
+4. Si aucune catégorie ne convient réellement → propose une nouvelle
+   catégorie avec un nom et une description clairs, et mets
+   "nouvelle_categorie": true dans ta réponse.
+
+Retourne UNIQUEMENT un JSON valide, sans markdown, sans explication :
+{
+  "titre": "Titre court et clair (max 60 caractères)",
+  "contenu": "Description reformulée, concise, phrase nominale ou infinitif",
+  "categorie": "chemin/exact/de/la/categorie",
+  "nouvelle_categorie": false,
+  "nouvelle_categorie_description": "",
+  "raisonnement": "Pourquoi ce choix de catégorie (1 phrase)",
+  "tags": ["tag1", "tag2"],
+  "priorite": "haute | normale | basse"
+}
+
+Ne reformule pas excessivement. Garde l'intention originale. Sois concis.`;
+}
+
+function httpsRequest(options, body) {
+    return new Promise((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Groq API timeout (30s)')), TIMEOUT_MS);
+
+        const req = https.request(options, (res) => {
+            let data = '';
+            res.on('data', chunk => { data += chunk; });
+            res.on('end', () => {
+                clearTimeout(timer);
+                if (res.statusCode >= 400) {
+                    reject(new Error(`Groq API HTTP ${res.statusCode}: ${data}`));
+                    return;
+                }
+                try {
+                    resolve(JSON.parse(data));
+                } catch (e) {
+                    reject(new Error(`Groq API invalid JSON: ${data.slice(0, 200)}`));
+                }
+            });
+        });
+
+        req.on('error', (err) => {
+            clearTimeout(timer);
+            reject(err);
+        });
+
+        req.write(body);
+        req.end();
+    });
+}
+
+function parseGroqResponse(content) {
+    // Strip potential markdown code fences
+    const cleaned = content
+        .replace(/^```(?:json)?\n?/m, '')
+        .replace(/\n?```$/m, '')
+        .trim();
+
+    let parsed;
+    try {
+        parsed = JSON.parse(cleaned);
+    } catch {
+        // Best-effort: try to extract JSON object
+        const match = cleaned.match(/\{[\s\S]+\}/);
+        if (!match) throw new Error(`Cannot parse Groq response: ${cleaned.slice(0, 300)}`);
+        parsed = JSON.parse(match[0]);
+    }
+
+    // Normalize and validate fields
+    return {
+        titre: String(parsed.titre || 'Note sans titre').slice(0, 60),
+        contenu: String(parsed.contenu || ''),
+        categorie: String(parsed.categorie || '_Inbox'),
+        nouvelle_categorie: Boolean(parsed.nouvelle_categorie),
+        nouvelle_categorie_description: String(parsed.nouvelle_categorie_description || ''),
+        raisonnement: String(parsed.raisonnement || ''),
+        tags: Array.isArray(parsed.tags) ? parsed.tags.map(String) : [],
+        priorite: ['haute', 'normale', 'basse'].includes(parsed.priorite) ? parsed.priorite : 'normale',
+    };
+}
+
+/**
+ * @param {string} rawText - Raw transcription or text message
+ * @param {Array} categories - Array of category objects from categories.json
+ * @returns {Promise<Object>} Parsed AI response
+ */
+async function callGroqAPI(rawText, categories) {
+    const apiKey = process.env.GROQ_API_KEY;
+    if (!apiKey) throw new Error('GROQ_API_KEY not set');
+
+    const systemPrompt = buildSystemPrompt(categories);
+    const requestBody = JSON.stringify({
+        model: GROQ_MODEL,
+        messages: [
+            { role: 'system', content: systemPrompt },
+            { role: 'user', content: rawText },
+        ],
+        temperature: 0.3,
+        max_tokens: 512,
+    });
+
+    const url = new URL(GROQ_API_URL);
+    const options = {
+        hostname: url.hostname,
+        path: url.pathname,
+        method: 'POST',
+        headers: {
+            'Authorization': `Bearer ${apiKey}`,
+            'Content-Type': 'application/json',
+            'Content-Length': Buffer.byteLength(requestBody),
+        },
+    };
+
+    const t0 = Date.now();
+    console.log('[groq] Appel API...');
+
+    const response = await httpsRequest(options, requestBody);
+    const elapsed = Date.now() - t0;
+    console.log(`[groq] Réponse reçue (${elapsed}ms)`);
+
+    const content = response.choices?.[0]?.message?.content;
+    if (!content) throw new Error('Groq API returned empty content');
+
+    return parseGroqResponse(content);
+}
+
+module.exports = { callGroqAPI, buildSystemPrompt };

--- a/pipeline/transcriber.js
+++ b/pipeline/transcriber.js
@@ -1,0 +1,184 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const { v4: uuidv4 } = require('uuid');
+
+const TMP_DIR = path.resolve(__dirname, '..', 'tmp', 'audio');
+const TRANSCRIBE_SCRIPT = path.resolve(__dirname, '..', 'transcriber', 'transcribe.py');
+
+const TRANSCRIPTION_TIMEOUT_MS = 5 * 60 * 1000; // 5 minutes
+
+/**
+ * Ensure the tmp/audio directory exists before writing files into it.
+ */
+function ensureTmpDir() {
+    if (!fs.existsSync(TMP_DIR)) {
+        fs.mkdirSync(TMP_DIR, { recursive: true });
+    }
+}
+
+/**
+ * Convert an audio file to 16 kHz mono WAV using ffmpeg.
+ * Uses spawn (not exec) so large outputs never overflow a buffer.
+ *
+ * @param {string} inputPath  — Absolute path to the source audio file.
+ * @param {string} outputPath — Absolute path for the output WAV file.
+ * @returns {Promise<void>}
+ */
+function convertToWav(inputPath, outputPath) {
+    return new Promise((resolve, reject) => {
+        console.log('[transcriber] Conversion ffmpeg...');
+
+        const args = [
+            '-i', inputPath,
+            '-ar', '16000',
+            '-ac', '1',
+            '-y',
+            outputPath,
+        ];
+
+        const proc = spawn('ffmpeg', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+        let stderrBuf = '';
+        proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+
+        proc.on('error', (err) => {
+            reject(new Error(`[transcriber] ffmpeg spawn error: ${err.message}`));
+        });
+
+        proc.on('close', (code) => {
+            if (code === 0) {
+                resolve();
+            } else {
+                reject(new Error(`[transcriber] ffmpeg exited with code ${code}: ${stderrBuf.slice(-500)}`));
+            }
+        });
+    });
+}
+
+/**
+ * Run the Python faster-whisper script and return the transcribed text.
+ *
+ * @param {string} wavPath — Absolute path to the 16 kHz mono WAV file.
+ * @returns {Promise<string>} — Transcribed text.
+ */
+function transcribeWhisper(wavPath) {
+    const model = process.env.WHISPER_MODEL || 'medium';
+    const language = process.env.WHISPER_LANGUAGE || 'fr';
+
+    return new Promise((resolve, reject) => {
+        console.log(`[transcriber] Transcription Whisper (modèle: ${model})...`);
+        const startTime = Date.now();
+
+        const args = [
+            TRANSCRIBE_SCRIPT,
+            '--file', wavPath,
+            '--model', model,
+            '--language', language,
+        ];
+
+        const proc = spawn('python3', args, { stdio: ['ignore', 'pipe', 'pipe'] });
+
+        let stdoutBuf = '';
+        let stderrBuf = '';
+
+        proc.stdout.on('data', (chunk) => { stdoutBuf += chunk.toString(); });
+        proc.stderr.on('data', (chunk) => { stderrBuf += chunk.toString(); });
+
+        // Hard timeout: kill the process if transcription hangs.
+        const timer = setTimeout(() => {
+            proc.kill('SIGKILL');
+            reject(new Error(`[transcriber] Whisper timeout after ${TRANSCRIPTION_TIMEOUT_MS / 1000}s`));
+        }, TRANSCRIPTION_TIMEOUT_MS);
+
+        proc.on('error', (err) => {
+            clearTimeout(timer);
+            reject(new Error(`[transcriber] python3 spawn error: ${err.message}`));
+        });
+
+        proc.on('close', (code) => {
+            clearTimeout(timer);
+
+            const elapsed = Date.now() - startTime;
+            let parsed;
+
+            try {
+                parsed = JSON.parse(stdoutBuf.trim());
+            } catch (_) {
+                return reject(new Error(
+                    `[transcriber] Réponse JSON invalide depuis transcribe.py: ${stdoutBuf.slice(0, 200)}`
+                ));
+            }
+
+            if (parsed.error) {
+                return reject(new Error(`[transcriber] Whisper error: ${parsed.error}`));
+            }
+
+            if (code !== 0) {
+                return reject(new Error(
+                    `[transcriber] transcribe.py exited ${code}: ${stderrBuf.slice(-300)}`
+                ));
+            }
+
+            console.log(`[transcriber] Terminé en ${elapsed}ms`);
+            resolve(parsed.text || '');
+        });
+    });
+}
+
+/**
+ * Persist a base64-encoded audio buffer as a .ogg file and prepare WAV path.
+ * The caller is responsible for running convertToWav before transcribeWhisper.
+ *
+ * @param {string|Buffer} mediaData — Raw audio bytes or base64-encoded string.
+ * @returns {{ id: string, oggPath: string, wavPath: string }}
+ */
+function saveAudio(mediaData) {
+    ensureTmpDir();
+
+    const id = uuidv4();
+    const oggPath = path.join(TMP_DIR, `audio-${id}.ogg`);
+    const wavPath = path.join(TMP_DIR, `audio-${id}.wav`);
+
+    const buffer = Buffer.isBuffer(mediaData)
+        ? mediaData
+        : Buffer.from(mediaData, 'base64');
+
+    fs.writeFileSync(oggPath, buffer);
+
+    return { id, oggPath, wavPath };
+}
+
+/**
+ * Delete all `audio-*` files in the tmp/audio directory.
+ * Runs synchronously; intended for startup cleanup or maintenance tasks.
+ *
+ * @param {string} [tmpDir] — Override directory path (defaults to tmp/audio).
+ */
+function purgeStaleAudioFiles(tmpDir) {
+    const targetDir = tmpDir || TMP_DIR;
+
+    if (!fs.existsSync(targetDir)) return;
+
+    const entries = fs.readdirSync(targetDir);
+    let removed = 0;
+
+    for (const entry of entries) {
+        if (entry.startsWith('audio-')) {
+            try {
+                fs.unlinkSync(path.join(targetDir, entry));
+                removed++;
+            } catch (err) {
+                console.warn(`[transcriber] Impossible de supprimer ${entry}: ${err.message}`);
+            }
+        }
+    }
+
+    if (removed > 0) {
+        console.log(`[transcriber] ${removed} fichier(s) audio périmé(s) supprimé(s)`);
+    }
+}
+
+module.exports = { convertToWav, transcribeWhisper, saveAudio, purgeStaleAudioFiles };

--- a/pipeline/vaultWriter.js
+++ b/pipeline/vaultWriter.js
@@ -1,0 +1,161 @@
+const fs = require('fs');
+const path = require('path');
+
+/**
+ * Slugify a title without external dependencies.
+ * Lowercases, strips diacritics, replaces non-alphanumeric runs with hyphens,
+ * trims leading/trailing hyphens, and caps at 60 characters.
+ *
+ * @param {string} text
+ * @returns {string}
+ */
+function slugify(text) {
+    return text
+        .toLowerCase()
+        .normalize('NFD')
+        .replace(/[̀-ͯ]/g, '')
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, 60);
+}
+
+/**
+ * Format a Date as "YYYY-MM-DDTHH-MM" for use in filenames.
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatDateForFilename(date) {
+    const pad = n => String(n).padStart(2, '0');
+    return (
+        date.getFullYear() +
+        '-' + pad(date.getMonth() + 1) +
+        '-' + pad(date.getDate()) +
+        '_' + pad(date.getHours()) +
+        '-' + pad(date.getMinutes())
+    );
+}
+
+/**
+ * Format a Date as ISO 8601 without milliseconds.
+ *
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatDateISO(date) {
+    const pad = n => String(n).padStart(2, '0');
+    return (
+        date.getFullYear() +
+        '-' + pad(date.getMonth() + 1) +
+        '-' + pad(date.getDate()) +
+        'T' + pad(date.getHours()) +
+        ':' + pad(date.getMinutes()) +
+        ':' + pad(date.getSeconds())
+    );
+}
+
+/**
+ * Determine whether the message source is a voice note or plain text based on
+ * the source identifier convention: "<channel>-vocal" | "<channel>-texte".
+ *
+ * @param {string} source  e.g. "telegram-vocal" or "whatsapp-texte"
+ * @returns {"vocal"|"texte"}
+ */
+function sourceType(source) {
+    return source && source.endsWith('-vocal') ? 'vocal' : 'texte';
+}
+
+/**
+ * Build the YAML frontmatter block for a note.
+ *
+ * @param {object} noteData
+ * @param {string} categoryPath
+ * @param {Date}   date
+ * @returns {string}
+ */
+function buildFrontmatter(noteData, categoryPath, date) {
+    const { source, tags = [], priorite = 'normale', raisonnement, categorie_suggeree } = noteData;
+    const isInbox = categoryPath === '_Inbox';
+
+    const effectiveTags = isInbox ? ['a-classer'] : tags;
+    const statut = isInbox ? 'a-classer' : 'nouveau';
+
+    const tagsFormatted = '[' + effectiveTags.map(t => t).join(', ') + ']';
+
+    let frontmatter = '---\n';
+    frontmatter += `date: ${formatDateISO(date)}\n`;
+    frontmatter += `source: ${source || 'unknown'}\n`;
+    frontmatter += `categorie: ${categoryPath}\n`;
+    frontmatter += `tags: ${tagsFormatted}\n`;
+    frontmatter += `priorite: ${priorite}\n`;
+    frontmatter += `statut: ${statut}\n`;
+    if (raisonnement) {
+        frontmatter += `raisonnement_ia: "${raisonnement.replace(/"/g, '\\"')}"\n`;
+    }
+    if (isInbox && categorie_suggeree) {
+        frontmatter += `categorie_suggeree: ${categorie_suggeree}\n`;
+    }
+    frontmatter += '---';
+    return frontmatter;
+}
+
+/**
+ * Build the Markdown body of a note.
+ *
+ * @param {object} noteData
+ * @returns {string}
+ */
+function buildBody(noteData, categoryPath) {
+    const { titre, contenu, rawText, source } = noteData;
+    const type = sourceType(source);
+    const isInbox = categoryPath === '_Inbox';
+
+    const originalLabel = (type === 'vocal' || isInbox)
+        ? '*Transcription originale :*'
+        : '*Message original :*';
+
+    return `# ${titre}\n\n${contenu}\n\n---\n${originalLabel} "${rawText}"`;
+}
+
+/**
+ * Write a Markdown note into the Obsidian vault.
+ *
+ * @param {object} noteData
+ *   @property {string}   titre               Note title
+ *   @property {string}   contenu             AI-reformulated content
+ *   @property {string}   rawText             Original transcription / message
+ *   @property {string}   source              Channel identifier, e.g. "telegram-vocal"
+ *   @property {string[]} [tags]              Array of tag strings
+ *   @property {string}   [priorite]          Priority level (default: "normale")
+ *   @property {string}   [raisonnement]      AI reasoning for category choice
+ *   @property {string}   [categorie_suggeree] Suggested category when filing to _Inbox
+ * @param {string} categoryPath  Vault-relative path such as "Projets/Tech" or "_Inbox"
+ * @returns {string} Absolute path of the written file
+ */
+function writeNote(noteData, categoryPath) {
+    const vaultPath = process.env.VAULT_PATH || '';
+    const now = new Date();
+
+    // Build filename: YYYY-MM-DD_HH-MM_slug.md
+    const slug = slugify(noteData.titre || 'note');
+    const datePart = formatDateForFilename(now);
+    const filename = `${datePart}_${slug}.md`;
+
+    // Resolve and ensure destination directory exists
+    const destDir = path.join(vaultPath, categoryPath);
+    fs.mkdirSync(destDir, { recursive: true });
+
+    const filePath = path.join(destDir, filename);
+
+    // Assemble note content
+    const frontmatter = buildFrontmatter(noteData, categoryPath, now);
+    const body = buildBody(noteData, categoryPath);
+    const content = `${frontmatter}\n\n${body}\n`;
+
+    fs.writeFileSync(filePath, content, 'utf8');
+    console.log(`[vault] Note écrite : ${filePath}`);
+
+    return filePath;
+}
+
+module.exports = { writeNote, slugify };

--- a/transcriber/transcribe.py
+++ b/transcriber/transcribe.py
@@ -1,0 +1,44 @@
+import sys
+import json
+import argparse
+import time
+from faster_whisper import WhisperModel
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Transcribe a WAV file using faster-whisper and emit JSON on stdout."
+    )
+    parser.add_argument('--file', required=True, help='Path to the 16 kHz mono WAV file')
+    parser.add_argument('--model', default='medium', help='Whisper model size (default: medium)')
+    parser.add_argument('--language', default='fr', help='Audio language code (default: fr)')
+    args = parser.parse_args()
+
+    try:
+        start = time.time()
+
+        print(f"[whisper] Chargement modèle {args.model}...", file=sys.stderr, flush=True)
+        model = WhisperModel(args.model, device="cpu", compute_type="int8")
+
+        print(f"[whisper] Transcription de {args.file} (langue: {args.language})...", file=sys.stderr, flush=True)
+        segments, info = model.transcribe(args.file, language=args.language, beam_size=5)
+
+        # Segments is a lazy generator — consume it fully before measuring duration.
+        text = " ".join(seg.text.strip() for seg in segments)
+        duration = round(time.time() - start, 2)
+
+        print(f"[whisper] Terminé en {duration}s", file=sys.stderr, flush=True)
+
+        print(json.dumps({
+            "text": text,
+            "language": info.language,
+            "duration": duration,
+        }))
+
+    except Exception as e:
+        print(json.dumps({"error": str(e)}))
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary

- Add `pipeline/categories.js`: JSON-backed category registry with `loadCategories`, `addCategory`, and `initCategories`. Each operation also creates the matching physical directory inside the vault.
- Add `pipeline/vaultWriter.js`: generates Markdown notes with complete YAML frontmatter and writes them into the correct vault sub-directory. Handles `_Inbox` (tags `a-classer`, statut `a-classer`, optional `categorie_suggeree`) and named categories. Slugification is done with a native regex (no external `slugify` dependency).

## Design decisions

- **No external slugify**: native `String.normalize('NFD')` + regex chain covers accented characters without adding a dependency.
- **`sourceType` helper**: derives `vocal` / `texte` from the source identifier suffix to decide the "original" label in the note body.
- **Defensive `mkdirSync`**: both modules create missing directories with `{ recursive: true }` so the caller never needs to pre-provision the tree.
- **Exported `slugify`**: exposed from `vaultWriter.js` so upstream code (e.g. a deduplication check) can reuse the same normalisation logic.

## Test plan

- [ ] `initCategories('/tmp/vault', ['Projets/Tech', 'Idées'])` creates `categories.json` and two directories.
- [ ] `addCategory('Apprentissage/3D', 'Blender notes')` appends to `categories.json`, increments `version`, and creates the directory.
- [ ] `writeNote(noteData, 'Projets/Tech')` produces a `.md` file with correct frontmatter (`statut: nouveau`) and body.
- [ ] `writeNote(noteData, '_Inbox')` produces a `.md` file with `tags: [a-classer]`, `statut: a-classer`, and `categorie_suggeree` when provided.
- [ ] Slugified filename contains no accents or special characters and is capped at 60 chars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)