### PR TITLE
feat: implement pending approvals manager with disk persistence

### DIFF
--- a/adapters/whatsapp.js
+++ b/adapters/whatsapp.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcode = require('qrcode-terminal');
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const ChannelAdapter = require('./base');
+
+class WhatsAppAdapter extends ChannelAdapter {
+  /**
+   * @param {{ allowedNumber: string, sessionPath?: string, tmpPath?: string }} config
+   */
+  constructor(config) {
+    super();
+    // config: { allowedNumber, sessionPath, tmpPath }
+    this.allowedNumber = config.allowedNumber;
+    this.tmpPath = config.tmpPath || path.join(__dirname, '..', 'tmp', 'audio');
+    this.client = new Client({
+      authStrategy: new LocalAuth({ dataPath: config.sessionPath || '.wwebjs_auth' }),
+      puppeteer: {
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+      },
+    });
+  }
+
+  /**
+   * Initialises the WhatsApp client, displays the QR code for pairing,
+   * and resolves once the session is ready.
+   * @returns {Promise<void>}
+   */
+  async connect() {
+    return new Promise((resolve, reject) => {
+      this.client.on('qr', (qr) => {
+        console.log('\n[WhatsApp] Scanne ce QR code avec ton téléphone secondaire :');
+        qrcode.generate(qr, { small: true });
+      });
+
+      this.client.on('ready', () => {
+        console.log('[WhatsApp] Connecté');
+        resolve();
+      });
+
+      this.client.on('auth_failure', (msg) => {
+        console.error('[WhatsApp] Échec d\'authentification:', msg);
+        reject(new Error('WhatsApp auth failure: ' + msg));
+      });
+
+      this.client.on('disconnected', (reason) => {
+        console.warn('[WhatsApp] Déconnecté:', reason);
+        this.emit('disconnected', reason);
+      });
+
+      this.client.on('message', (msg) => this._onMessage(msg));
+
+      this.client.initialize().catch(reject);
+    });
+  }
+
+  /**
+   * Returns true when the incoming message originates from the configured
+   * allowed phone number. Handles the optional @c.us suffix and leading '+'.
+   * @param {Object} msg - Raw whatsapp-web.js message object
+   * @returns {boolean}
+   */
+  isAuthorized(msg) {
+    // Normalize: strip @c.us suffix for comparison if present
+    const from = msg.from.replace(/@c\.us$/, '');
+    const allowed = this.allowedNumber.replace(/^\+/, '').replace(/\s/g, '');
+    return from === allowed;
+  }
+
+  /**
+   * Processes a raw whatsapp-web.js message: authorisation check, type
+   * detection, NormalizedMessage construction, and event emission.
+   * @param {Object} msg - Raw whatsapp-web.js message object
+   */
+  async _onMessage(msg) {
+    if (!this.isAuthorized(msg)) return;
+    // Ignore status messages and group messages
+    if (msg.isStatus || msg.from.includes('@g.us')) return;
+
+    const isVoice = msg.type === 'ptt' || msg.type === 'audio';
+    const isText  = msg.type === 'chat';
+
+    if (!isVoice && !isText) return;
+
+    /** @type {import('./base').NormalizedMessage} */
+    const normalized = {
+      channelId: 'whatsapp',
+      from:      msg.from,
+      type:      isVoice ? 'voice' : 'text',
+      text:      isText ? (msg.body || '').trim() : null,
+      audioPath: null,
+      reply:      (text) => msg.reply(text),
+      replyVoice: (text) => msg.reply(text),
+    };
+
+    this.emit('message', normalized, msg);
+  }
+
+  /**
+   * Downloads the audio payload of a raw whatsapp-web.js voice/audio message
+   * to a local temp file and returns its path.
+   * @param {Object} rawMsg - Raw whatsapp-web.js message object
+   * @returns {Promise<string>} Local path to the downloaded audio file
+   */
+  async downloadAudio(rawMsg) {
+    if (!fs.existsSync(this.tmpPath)) {
+      fs.mkdirSync(this.tmpPath, { recursive: true });
+    }
+
+    const media = await rawMsg.downloadMedia();
+    if (!media || !media.data) {
+      throw new Error('[WhatsApp] downloadAudio: media data empty');
+    }
+
+    const ext = 'ogg';
+    const filename = `audio-${uuidv4()}.${ext}`;
+    const filePath = path.join(this.tmpPath, filename);
+
+    fs.writeFileSync(filePath, Buffer.from(media.data, 'base64'));
+    console.log(`[WhatsApp] Audio téléchargé: ${filename}`);
+
+    return filePath;
+  }
+
+  /**
+   * Sends a plain-text message to a WhatsApp contact or group.
+   * @param {string} to - WhatsApp ID (e.g. "33612345678@c.us")
+   * @param {string} text
+   * @returns {Promise<void>}
+   */
+  async send(to, text) {
+    await this.client.sendMessage(to, text);
+  }
+}
+
+module.exports = WhatsAppAdapter;

--- a/pipeline/pending.js
+++ b/pipeline/pending.js
@@ -1,0 +1,201 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { writeNote } = require('./vaultWriter');
+
+/**
+ * Return the absolute path to the pending proposals JSON file.
+ * Defaults to <repo-root>/pending.json; overridable via PENDING_FILE env var.
+ *
+ * @returns {string}
+ */
+function getPendingFile() {
+    return process.env.PENDING_FILE || path.join(__dirname, '..', 'pending.json');
+}
+
+/**
+ * Load the full list of pending entries from disk.
+ * Returns an empty array when the file does not exist or is malformed.
+ *
+ * @returns {Array<object>}
+ */
+function loadPending() {
+    const file = getPendingFile();
+    if (!fs.existsSync(file)) return [];
+    try {
+        return JSON.parse(fs.readFileSync(file, 'utf8')).pending || [];
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Persist the given entries array to disk atomically (overwrite).
+ *
+ * @param {Array<object>} entries
+ */
+function savePending(entries) {
+    fs.writeFileSync(getPendingFile(), JSON.stringify({ pending: entries }, null, 2), 'utf8');
+}
+
+/**
+ * Append a new proposal entry to the pending store.
+ *
+ * Expected entry shape:
+ * {
+ *   id:                    string  — unique identifier (e.g. `${channelId}-${from}-${Date.now()}`)
+ *   from:                  string  — sender identifier (phone / Telegram user-id)
+ *   channelId:             string  — 'telegram' | 'whatsapp'
+ *   status:                'pending'
+ *   suggestedCategory:     string  — new category path suggested by the AI
+ *   suggestedDescription:  string  — one-line description of the new category
+ *   proposedAt:            string  — ISO 8601 timestamp
+ *   expiresAt:             string  — ISO 8601 timestamp (proposedAt + TTL)
+ *   note: {
+ *     titre:   string
+ *     contenu: string
+ *     rawText: string
+ *     source:  string
+ *     tags:    string[]
+ *     priorite: string
+ *     raisonnement: string
+ *   }
+ * }
+ *
+ * @param {object} entry
+ */
+function addPending(entry) {
+    const entries = loadPending();
+    entries.push(entry);
+    savePending(entries);
+    console.log(`[pending] Ajouté: ${entry.id} — catégorie suggérée: ${entry.suggestedCategory}`);
+}
+
+/**
+ * Remove a pending entry by its id.
+ *
+ * @param {string} id
+ */
+function removePending(id) {
+    const entries = loadPending().filter(e => e.id !== id);
+    savePending(entries);
+    console.log(`[pending] Supprimé: ${id}`);
+}
+
+/**
+ * Return the oldest non-expired pending entry for a given sender (FIFO order).
+ * Only entries with status === 'pending' and a future expiresAt are returned.
+ *
+ * @param {string} from  — sender identifier
+ * @returns {object|null}
+ */
+function getPendingByFrom(from) {
+    return loadPending()
+        .filter(e => e.from === from && e.status === 'pending' && new Date(e.expiresAt) > new Date())
+        .sort((a, b) => new Date(a.proposedAt) - new Date(b.proposedAt))[0] || null;
+}
+
+/**
+ * Calculate the number of whole minutes remaining until the given ISO timestamp.
+ * Returns 0 when the timestamp is already in the past.
+ *
+ * @param {string} expiresAt  ISO 8601 string
+ * @returns {number}
+ */
+function minutesRemaining(expiresAt) {
+    return Math.max(0, Math.round((new Date(expiresAt) - new Date()) / 60000));
+}
+
+/**
+ * Called once at bot startup.
+ *
+ * For every persisted proposal:
+ *   - Expired entries  → filed to _Inbox via writeNote(), then removed from store.
+ *   - Live entries     → re-sent to the originating sender via the matching adapter
+ *                        so the user knows the proposal is still awaiting their reply.
+ *
+ * @param {Object.<string, import('../adapters/base')>} adapters
+ *   Map of channelId → ChannelAdapter instance (must implement send(to, text)).
+ * @returns {Promise<void>}
+ */
+async function recoverPendingOnStartup(adapters) {
+    const entries = loadPending();
+    const now = new Date();
+    let recovered = 0;
+    let expired = 0;
+
+    for (const entry of entries) {
+        if (new Date(entry.expiresAt) <= now) {
+            await writeNote(
+                { ...entry.note, categorie_suggeree: entry.suggestedCategory },
+                '_Inbox'
+            );
+            removePending(entry.id);
+            expired++;
+        } else {
+            const adapter = adapters[entry.channelId];
+            if (adapter) {
+                const mins = minutesRemaining(entry.expiresAt);
+                await adapter.send(
+                    entry.from,
+                    `Proposition en attente (reprise apres redemarrage)\n\n` +
+                    `Nouvelle categorie : *${entry.suggestedCategory}*\n` +
+                    `-> ${entry.suggestedDescription}\n\n` +
+                    `Reponds *OUI* pour creer, *NON* pour mettre en _Inbox\n` +
+                    `(Expire dans ${mins} min)`
+                );
+            }
+            recovered++;
+        }
+    }
+
+    if (recovered > 0 || expired > 0) {
+        console.log(`[pending] Demarrage: ${recovered} relancee(s), ${expired} expiree(s) -> _Inbox`);
+    }
+}
+
+/**
+ * Start a periodic watcher (every 60 seconds) that detects proposals whose
+ * timeout has elapsed while the bot is running.
+ *
+ * For each expired proposal the note is filed to _Inbox and the sender receives
+ * a timeout notification via the matching adapter.
+ *
+ * @param {Object.<string, import('../adapters/base')>} adapters
+ *   Map of channelId → ChannelAdapter instance (must implement send(to, text)).
+ * @returns {NodeJS.Timeout}  The interval handle (call clearInterval() to stop).
+ */
+function startTimeoutWatcher(adapters) {
+    return setInterval(async () => {
+        const entries = loadPending();
+        const now = new Date();
+
+        for (const entry of entries) {
+            if (entry.status === 'pending' && new Date(entry.expiresAt) <= now) {
+                await writeNote(
+                    { ...entry.note, categorie_suggeree: entry.suggestedCategory },
+                    '_Inbox'
+                );
+                removePending(entry.id);
+
+                const adapter = adapters[entry.channelId];
+                if (adapter) {
+                    await adapter.send(
+                        entry.from,
+                        `Timeout — la note *"${entry.note.titre}"* a ete placee en _Inbox.\n` +
+                        `Categorie suggeree conservee dans le frontmatter : ${entry.suggestedCategory}`
+                    );
+                }
+            }
+        }
+    }, 60 * 1000);
+}
+
+module.exports = {
+    addPending,
+    removePending,
+    getPendingByFrom,
+    recoverPendingOnStartup,
+    startTimeoutWatcher,
+};


### PR DESCRIPTION
## Summary

- Adds `pipeline/pending.js`, a CommonJS module that persists new-category approval proposals to `pending.json` on disk
- Implements FIFO retrieval per sender (`getPendingByFrom`), startup recovery (`recoverPendingOnStartup`), and a 60-second `setInterval` watcher (`startTimeoutWatcher`) for runtime timeouts
- Expired entries are automatically filed to `_Inbox` via `writeNote`; live entries are re-sent to the user through their originating adapter on bot restart

## Test plan

- [ ] `node -e "require('./pipeline/pending.js')"` exits without error
- [ ] `addPending` writes a new entry to `pending.json`; `loadPending` reads it back correctly
- [ ] `getPendingByFrom` returns the oldest non-expired entry for a sender and `null` when all entries are expired or absent
- [ ] `removePending` removes only the target entry by id
- [ ] `recoverPendingOnStartup`: expired entries → `_Inbox` note written + removed from store; live entries → adapter.send called with correct message and remaining minutes
- [ ] `startTimeoutWatcher`: interval fires, detects an expired entry, writes it to `_Inbox`, removes from store, and notifies the sender via adapter

Closes #8

Generated with [Claude Code](https://claude.com/claude-code)