### PR TITLE
feat: implement WhatsApp channel adapter with LocalAuth and QR scan

### DIFF
--- a/adapters/whatsapp.js
+++ b/adapters/whatsapp.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const { Client, LocalAuth } = require('whatsapp-web.js');
+const qrcode = require('qrcode-terminal');
+const fs = require('fs');
+const path = require('path');
+const { v4: uuidv4 } = require('uuid');
+const ChannelAdapter = require('./base');
+
+class WhatsAppAdapter extends ChannelAdapter {
+  /**
+   * @param {{ allowedNumber: string, sessionPath?: string, tmpPath?: string }} config
+   */
+  constructor(config) {
+    super();
+    // config: { allowedNumber, sessionPath, tmpPath }
+    this.allowedNumber = config.allowedNumber;
+    this.tmpPath = config.tmpPath || path.join(__dirname, '..', 'tmp', 'audio');
+    this.client = new Client({
+      authStrategy: new LocalAuth({ dataPath: config.sessionPath || '.wwebjs_auth' }),
+      puppeteer: {
+        headless: true,
+        args: ['--no-sandbox', '--disable-setuid-sandbox', '--disable-dev-shm-usage'],
+      },
+    });
+  }
+
+  /**
+   * Initialises the WhatsApp client, displays the QR code for pairing,
+   * and resolves once the session is ready.
+   * @returns {Promise<void>}
+   */
+  async connect() {
+    return new Promise((resolve, reject) => {
+      this.client.on('qr', (qr) => {
+        console.log('\n[WhatsApp] Scanne ce QR code avec ton téléphone secondaire :');
+        qrcode.generate(qr, { small: true });
+      });
+
+      this.client.on('ready', () => {
+        console.log('[WhatsApp] Connecté');
+        resolve();
+      });
+
+      this.client.on('auth_failure', (msg) => {
+        console.error('[WhatsApp] Échec d\'authentification:', msg);
+        reject(new Error('WhatsApp auth failure: ' + msg));
+      });
+
+      this.client.on('disconnected', (reason) => {
+        console.warn('[WhatsApp] Déconnecté:', reason);
+        this.emit('disconnected', reason);
+      });
+
+      this.client.on('message', (msg) => this._onMessage(msg));
+
+      this.client.initialize().catch(reject);
+    });
+  }
+
+  /**
+   * Returns true when the incoming message originates from the configured
+   * allowed phone number. Handles the optional @c.us suffix and leading '+'.
+   * @param {Object} msg - Raw whatsapp-web.js message object
+   * @returns {boolean}
+   */
+  isAuthorized(msg) {
+    // Normalize: strip @c.us suffix for comparison if present
+    const from = msg.from.replace(/@c\.us$/, '');
+    const allowed = this.allowedNumber.replace(/^\+/, '').replace(/\s/g, '');
+    return from === allowed;
+  }
+
+  /**
+   * Processes a raw whatsapp-web.js message: authorisation check, type
+   * detection, NormalizedMessage construction, and event emission.
+   * @param {Object} msg - Raw whatsapp-web.js message object
+   */
+  async _onMessage(msg) {
+    if (!this.isAuthorized(msg)) return;
+    // Ignore status messages and group messages
+    if (msg.isStatus || msg.from.includes('@g.us')) return;
+
+    const isVoice = msg.type === 'ptt' || msg.type === 'audio';
+    const isText  = msg.type === 'chat';
+
+    if (!isVoice && !isText) return;
+
+    /** @type {import('./base').NormalizedMessage} */
+    const normalized = {
+      channelId: 'whatsapp',
+      from:      msg.from,
+      type:      isVoice ? 'voice' : 'text',
+      text:      isText ? (msg.body || '').trim() : null,
+      audioPath: null,
+      reply:      (text) => msg.reply(text),
+      replyVoice: (text) => msg.reply(text),
+    };
+
+    this.emit('message', normalized, msg);
+  }
+
+  /**
+   * Downloads the audio payload of a raw whatsapp-web.js voice/audio message
+   * to a local temp file and returns its path.
+   * @param {Object} rawMsg - Raw whatsapp-web.js message object
+   * @returns {Promise<string>} Local path to the downloaded audio file
+   */
+  async downloadAudio(rawMsg) {
+    if (!fs.existsSync(this.tmpPath)) {
+      fs.mkdirSync(this.tmpPath, { recursive: true });
+    }
+
+    const media = await rawMsg.downloadMedia();
+    if (!media || !media.data) {
+      throw new Error('[WhatsApp] downloadAudio: media data empty');
+    }
+
+    const ext = 'ogg';
+    const filename = `audio-${uuidv4()}.${ext}`;
+    const filePath = path.join(this.tmpPath, filename);
+
+    fs.writeFileSync(filePath, Buffer.from(media.data, 'base64'));
+    console.log(`[WhatsApp] Audio téléchargé: ${filename}`);
+
+    return filePath;
+  }
+
+  /**
+   * Sends a plain-text message to a WhatsApp contact or group.
+   * @param {string} to - WhatsApp ID (e.g. "33612345678@c.us")
+   * @param {string} text
+   * @returns {Promise<void>}
+   */
+  async send(to, text) {
+    await this.client.sendMessage(to, text);
+  }
+}
+
+module.exports = WhatsAppAdapter;

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+'use strict';
+
+const { Command } = require('commander');
+const path = require('path');
+const { execSync, spawn } = require('child_process');
+
+const program = new Command();
+
+program
+    .name('voicenote')
+    .description('VoiceNote → Obsidian Pipeline CLI')
+    .version('1.0.0');
+
+program
+    .command('setup')
+    .description('Lancer le wizard de configuration interactif')
+    .action(() => {
+        require('./setup');
+    });
+
+program
+    .command('start')
+    .description('Démarrer le pipeline (tous les channels configurés)')
+    .option('--wa', 'WhatsApp uniquement')
+    .option('--tg', 'Telegram uniquement')
+    .action((opts) => {
+        const args = [path.join(__dirname, '..', 'index.js')];
+        if (opts.wa) args.push('--wa');
+        if (opts.tg) args.push('--tg');
+        const proc = spawn(process.execPath, args, { stdio: 'inherit' });
+        proc.on('exit', (code) => process.exit(code || 0));
+    });
+
+program
+    .command('status')
+    .description('Afficher l\'état du pipeline')
+    .action(() => {
+        const fs = require('fs');
+        const yaml = require('js-yaml');
+        const configPath = path.join(__dirname, '..', 'config.yaml');
+
+        if (!fs.existsSync(configPath)) {
+            console.log('❌ Pas de configuration. Lance "voicenote setup" d\'abord.');
+            return;
+        }
+
+        const cfg = yaml.load(fs.readFileSync(configPath, 'utf8'));
+        console.log('\n── Status VoiceNote Pipeline ──────────────────\n');
+        const wa = cfg.channels?.whatsapp;
+        const tg = cfg.channels?.telegram;
+        console.log(`WhatsApp : ${wa?.enabled ? '✅ Activé (' + wa.allowedNumber + ')' : '⬜ Désactivé'}`);
+        console.log(`Telegram : ${tg?.enabled ? '✅ Activé (userId: ' + tg.allowedUserId + ')' : '⬜ Désactivé'}`);
+        console.log(`Vault    : ${cfg.vault?.path || '❌ Non configurée'}`);
+        console.log(`Whisper  : ${cfg.whisper?.model || 'medium'} / ${cfg.whisper?.language || 'fr'}`);
+
+        const pendingFile = path.join(__dirname, '..', 'pending.json');
+        if (fs.existsSync(pendingFile)) {
+            const pending = JSON.parse(fs.readFileSync(pendingFile, 'utf8')).pending || [];
+            console.log(`Pending  : ${pending.length} proposition(s) en attente`);
+        }
+        console.log('');
+    });
+
+program
+    .command('categories')
+    .description('Lister les catégories actives')
+    .action(() => {
+        require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+        const { loadCategories } = require('../pipeline/categories');
+        const cats = loadCategories();
+        if (cats.length === 0) {
+            console.log('Aucune catégorie. Lance "voicenote setup" d\'abord.');
+            return;
+        }
+        console.log(`\n── ${cats.length} catégorie(s) ──────────────────────────\n`);
+        cats.forEach(c => {
+            console.log(`  📁 ${c.path}${c.description ? ' — ' + c.description : ''}`);
+        });
+        console.log('');
+    });
+
+program
+    .command('logs')
+    .description('Afficher les logs en temps réel')
+    .action(() => {
+        const logDir = path.join(__dirname, '..', 'logs');
+        const logFile = path.join(logDir, 'voicenote.log');
+        const fs = require('fs');
+        if (!fs.existsSync(logFile)) {
+            console.log('Aucun fichier de log trouvé. Démarre le pipeline avec "voicenote start".');
+            return;
+        }
+        const tail = spawn('tail', ['-f', logFile], { stdio: 'inherit' });
+        tail.on('exit', () => process.exit(0));
+    });
+
+program.parse(process.argv);

--- a/bin/setup.js
+++ b/bin/setup.js
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+'use strict';
+
+// Wizard CLI — voicenote setup
+// Uses inquirer v9 (dynamic import required for ESM-only package)
+
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+const { initCategories } = require('../pipeline/categories');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+async function run() {
+    // inquirer v9 is ESM-only — dynamic import required from CJS
+    const { default: inquirer } = await import('inquirer');
+    const { default: chalk } = await import('chalk');
+
+    console.log('\n' + chalk.bold.yellow('╔══════════════════════════════════════════╗'));
+    console.log(chalk.bold.yellow('║') + chalk.bold('   VoiceNote → Obsidian  Setup            ') + chalk.bold.yellow('║'));
+    console.log(chalk.bold.yellow('╚══════════════════════════════════════════╝'));
+    console.log('\nBienvenue ! Ce wizard va configurer ton pipeline de capture d\'idées.\n');
+
+    // ── Étape 1 — Canal(aux) ──────────────────────────────────────────────
+    console.log(chalk.cyan('── Étape 1 / 5 — Canal(aux) de messagerie ─────────\n'));
+
+    const { channels } = await inquirer.prompt([{
+        type: 'checkbox',
+        name: 'channels',
+        message: 'Quel(s) canal(aux) veux-tu activer ?',
+        choices: [
+            { name: 'WhatsApp', value: 'whatsapp' },
+            { name: 'Telegram', value: 'telegram' },
+        ],
+        validate: (v) => v.length > 0 || 'Sélectionne au moins un canal.',
+    }]);
+
+    const useWA = channels.includes('whatsapp');
+    const useTG = channels.includes('telegram');
+
+    const env = {};
+    const config = {
+        channels: { whatsapp: { enabled: false }, telegram: { enabled: false } },
+        vault: { categoriesFile: 'categories.json', inboxFolder: '_Inbox', inboxTag: 'a-classer' },
+        whisper: {},
+        pipeline: {},
+    };
+
+    // ── Étape 2a — WhatsApp ───────────────────────────────────────────────
+    if (useWA) {
+        console.log('\n' + chalk.cyan('── Étape 2a / 5 — Configuration WhatsApp ──────────\n'));
+        console.log(chalk.yellow('⚠️  WhatsApp nécessite un numéro secondaire dédié.'));
+        console.log(chalk.yellow('   Les CGU interdisent les bots — risque de ban sur ce numéro.'));
+        console.log(chalk.yellow('   Recommandé : eSIM (~5€/mois) ou vieux téléphone.\n'));
+
+        const { waNumber } = await inquirer.prompt([{
+            type: 'input',
+            name: 'waNumber',
+            message: 'Numéro autorisé (format international, ex: +41791234567) :',
+            validate: (v) => /^\+\d{7,15}$/.test(v.trim()) || 'Format invalide (ex: +41791234567)',
+        }]);
+
+        env.WA_ENABLED = 'true';
+        env.WA_ALLOWED_NUMBER = waNumber.trim();
+        config.channels.whatsapp = {
+            enabled: true,
+            allowedNumber: waNumber.trim(),
+            sessionPath: '.wwebjs_auth',
+        };
+
+        console.log(chalk.green('\n→ Un QR code s\'affichera au premier démarrage.'));
+        console.log(chalk.green('  Ouvre WhatsApp → Appareils liés → Lier un appareil.\n'));
+    }
+
+    // ── Étape 2b — Telegram ───────────────────────────────────────────────
+    if (useTG) {
+        console.log('\n' + chalk.cyan('── Étape 2b / 5 — Configuration Telegram ──────────\n'));
+        console.log('Token BotFather : obtenu via @BotFather sur Telegram');
+        console.log('Ton User ID     : envoie /start à @userinfobot\n');
+
+        const { tgToken, tgUserId } = await inquirer.prompt([
+            {
+                type: 'password',
+                name: 'tgToken',
+                message: 'Token BotFather :',
+                mask: '*',
+                validate: (v) => v.trim().length > 20 || 'Token invalide',
+            },
+            {
+                type: 'input',
+                name: 'tgUserId',
+                message: 'Ton Telegram User ID :',
+                validate: (v) => /^\d+$/.test(v.trim()) || 'User ID invalide (chiffres uniquement)',
+            },
+        ]);
+
+        env.TG_ENABLED = 'true';
+        env.TG_BOT_TOKEN = tgToken.trim();
+        env.TG_ALLOWED_USER_ID = tgUserId.trim();
+        config.channels.telegram = {
+            enabled: true,
+            allowedUserId: tgUserId.trim(),
+        };
+    }
+
+    // ── Étape 3 — Vault ───────────────────────────────────────────────────
+    console.log('\n' + chalk.cyan('── Étape 3 / 5 — Vault Obsidian ───────────────────\n'));
+
+    const { vaultPath, categoriesRaw } = await inquirer.prompt([
+        {
+            type: 'input',
+            name: 'vaultPath',
+            message: 'Chemin absolu vers ta vault Obsidian :',
+            default: '/home/ubuntu/obsidian-vault',
+            validate: (v) => {
+                const p = v.trim();
+                if (!path.isAbsolute(p)) return 'Le chemin doit être absolu';
+                return true;
+            },
+        },
+        {
+            type: 'input',
+            name: 'categoriesRaw',
+            message: 'Catégories initiales (séparées par virgule) :',
+            default: 'Projets/Tech, Projets/Personnel, Idées, Apprentissage, Tâches',
+        },
+    ]);
+
+    const vaultAbsPath = vaultPath.trim();
+    const initialCategories = categoriesRaw.split(',').map(c => c.trim()).filter(Boolean);
+
+    env.VAULT_PATH = vaultAbsPath;
+    env.CATEGORIES_FILE = path.join(vaultAbsPath, 'categories.json');
+    env.PENDING_FILE = path.join(PROJECT_ROOT, 'pending.json');
+    env.TMP_PATH = path.join(PROJECT_ROOT, 'tmp', 'audio');
+
+    config.vault.path = vaultAbsPath;
+
+    // ── Étape 4 — Whisper & Groq ──────────────────────────────────────────
+    console.log('\n' + chalk.cyan('── Étape 4 / 5 — Transcription & IA ───────────────\n'));
+    console.log('Modèles Whisper : tiny | base | small | medium | large-v3');
+    console.log(chalk.dim('Recommandé : medium (bon équilibre vitesse/qualité)\n'));
+
+    const { whisperModel, whisperLang, groqKey } = await inquirer.prompt([
+        {
+            type: 'list',
+            name: 'whisperModel',
+            message: 'Modèle Whisper :',
+            choices: ['tiny', 'base', 'small', 'medium', 'large-v3'],
+            default: 'medium',
+        },
+        {
+            type: 'input',
+            name: 'whisperLang',
+            message: 'Langue principale de tes vocaux (code ISO) :',
+            default: 'fr',
+            validate: (v) => /^[a-z]{2}$/.test(v.trim()) || 'Code langue invalide (ex: fr, en, ar)',
+        },
+        {
+            type: 'password',
+            name: 'groqKey',
+            message: 'Clé API Groq (console.groq.com — gratuit) :',
+            mask: '*',
+            validate: (v) => v.trim().startsWith('gsk_') || 'Clé invalide (doit commencer par gsk_)',
+        },
+    ]);
+
+    env.WHISPER_MODEL = whisperModel;
+    env.WHISPER_LANGUAGE = whisperLang.trim();
+    env.GROQ_API_KEY = groqKey.trim();
+    env.CATEGORY_APPROVAL_TIMEOUT_MIN = '10';
+    env.INBOX_TAG = 'a-classer';
+
+    config.whisper = { model: whisperModel, language: whisperLang.trim() };
+    config.pipeline = {
+        categoryApprovalTimeoutMin: 10,
+        audioTmpPath: env.TMP_PATH,
+    };
+
+    // ── Étape 5 — Récapitulatif ───────────────────────────────────────────
+    console.log('\n' + chalk.cyan('── Étape 5 / 5 — Vérification ─────────────────────\n'));
+
+    if (useWA) console.log(chalk.green(`  ✅ WhatsApp    → ${env.WA_ALLOWED_NUMBER}`));
+    if (useTG)  console.log(chalk.green(`  ✅ Telegram    → User ID: ${env.TG_ALLOWED_USER_ID}`));
+    console.log(chalk.green(`  ✅ Vault       → ${vaultAbsPath}`));
+    console.log(chalk.green(`  ✅ Catégories  → ${initialCategories.length} à créer`));
+    console.log(chalk.green(`  ✅ Whisper     → ${whisperModel}, langue: ${whisperLang}`));
+    console.log(chalk.green(`  ✅ Groq API    → Clé configurée`));
+
+    const { confirm } = await inquirer.prompt([{
+        type: 'confirm',
+        name: 'confirm',
+        message: '\nTout est prêt. Générer la configuration et démarrer ?',
+        default: true,
+    }]);
+
+    if (!confirm) {
+        console.log(chalk.yellow('\nConfiguration annulée. Relance "voicenote setup" quand tu es prêt.'));
+        process.exit(0);
+    }
+
+    // ── Génération des fichiers ───────────────────────────────────────────
+    console.log('\n' + chalk.bold('🔧 Génération de la configuration...\n'));
+
+    // config.yaml
+    const configPath = path.join(PROJECT_ROOT, 'config.yaml');
+    fs.writeFileSync(configPath, yaml.dump(config, { indent: 2 }), 'utf8');
+    console.log(chalk.green('  ✅ config.yaml généré'));
+
+    // .env
+    const envPath = path.join(PROJECT_ROOT, '.env');
+    const envLines = Object.entries(env).map(([k, v]) => `${k}=${v}`).join('\n');
+    fs.writeFileSync(envPath, envLines + '\n', 'utf8');
+    console.log(chalk.green('  ✅ .env généré'));
+
+    // Vault + catégories initiales
+    fs.mkdirSync(vaultAbsPath, { recursive: true });
+    fs.mkdirSync(path.join(vaultAbsPath, '_Inbox'), { recursive: true });
+    fs.mkdirSync(path.join(PROJECT_ROOT, 'tmp', 'audio'), { recursive: true });
+
+    // Set env vars for initCategories
+    process.env.VAULT_PATH = vaultAbsPath;
+    process.env.CATEGORIES_FILE = env.CATEGORIES_FILE;
+    initCategories(vaultAbsPath, initialCategories);
+    console.log(chalk.green(`  ✅ Vault initialisée avec ${initialCategories.length} catégorie(s)`));
+
+    console.log('\n' + chalk.bold.green('🚀 Configuration terminée !'));
+    console.log(chalk.dim('\nDémarre le pipeline avec : ') + chalk.bold('voicenote start'));
+    if (useWA) {
+        console.log(chalk.dim('WhatsApp uniquement    : ') + chalk.bold('voicenote start --wa'));
+    }
+    if (useTG) {
+        console.log(chalk.dim('Telegram uniquement    : ') + chalk.bold('voicenote start --tg'));
+    }
+    console.log('');
+}
+
+run().catch((err) => {
+    console.error('\n❌ Erreur wizard :', err.message);
+    process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Adds `adapters/whatsapp.js` implementing `WhatsAppAdapter extends ChannelAdapter` (issue #4)
- QR-based pairing via `whatsapp-web.js` `LocalAuth` strategy with configurable session path
- Normalises `ptt` (voice note), `audio`, and `chat` messages into the shared `NormalizedMessage` shape consumed by the pipeline
- Filters out unauthorised senders, WhatsApp status messages (`isStatus`), and group messages (`@g.us`)
- `downloadAudio()` fetches the media payload and persists it as an OGG file under `tmp/audio/` (UUID-named, directory auto-created)
- Phone number normalisation strips leading `+` and `@c.us` suffix for reliable comparison
- Puppeteer launched with `--no-sandbox` / `--disable-dev-shm-usage` flags for VPS compatibility

## Test plan

- [ ] Instantiate `WhatsAppAdapter` with a valid `allowedNumber` and confirm QR is printed on first run
- [ ] Re-run with an existing `sessionPath` — should reconnect without QR
- [ ] Send a voice note from the allowed number — verify `message` event emits with `type: 'voice'` and `audioPath: null` (download happens upstream in the pipeline)
- [ ] Call `downloadAudio(rawMsg)` on the raw message — verify an `.ogg` file appears in `tmp/audio/`
- [ ] Send a text message — verify `message` event emits with `type: 'text'` and correct `text` field
- [ ] Send from an unauthorised number — verify no event is emitted
- [ ] Send from a group — verify no event is emitted
- [ ] Verify `send(to, text)` delivers a message back to the sender

Generated with [Claude Code](https://claude.com/claude-code)